### PR TITLE
Makefile.kernel: remove `.cache.mk`

### DIFF
--- a/vmmon-only/Makefile.kernel
+++ b/vmmon-only/Makefile.kernel
@@ -31,7 +31,7 @@ $(DRIVER)-y := $(subst $(SRCROOT)/, , $(patsubst %.c, %.o, \
 		$(SRCROOT)/bootstrap/*.c)))
 
 clean:
-	rm -rf $(wildcard $(DRIVER).mod.c $(DRIVER).ko .tmp_versions \
+	rm -rf $(wildcard $(DRIVER).mod.c $(DRIVER).ko .tmp_versions .cache.mk \
 		Module.symvers Modules.symvers Module.markers modules.order \
 		$(foreach dir,linux/ common/ vmcore/ bootstrap/ \
 		./,$(addprefix $(dir),.*.cmd .*.o.flags *.o)))

--- a/vmnet-only/Makefile.kernel
+++ b/vmnet-only/Makefile.kernel
@@ -32,6 +32,6 @@ $(DRIVER)-y := driver.o hub.o userif.o netif.o bridge.o procfs.o smac_compat.o \
 ####
 
 clean:
-	rm -rf $(DRIVER).o $(DRIVER).mod.o $(DRIVER).mod.c $(DRIVER).ko \
+	rm -rf $(DRIVER).o $(DRIVER).mod.o $(DRIVER).mod.c $(DRIVER).ko .cache.mk \
 	       .tmp_versions Module.symvers Modules.symvers Module.markers \
 	       modules.order $($(DRIVER)-y) .*.cmd .*.o.flags


### PR DESCRIPTION
Remove `.cache.mk` inside `vmmon-only` & `vmnet-only` when executing
`make clean` : `.cache.mk` can cause issue when upgrading `gcc`, as
`make` will still looking for includes inside older gcc includes folder
(typically `/usr/lib/gcc/x86_64-pc-linux-gnu/{gcc-version}`).