### PR TITLE
Fixes for 5.8

### DIFF
--- a/vmmon-only/linux/hostif.c
+++ b/vmmon-only/linux/hostif.c
@@ -47,6 +47,7 @@
 #include <asm/asm.h>
 #include <asm/io.h>
 #include <asm/page.h>
+#include <asm/tlbflush.h>
 #include <asm/uaccess.h>
 #include <asm/irq_vectors.h>
 #include <linux/capability.h>
@@ -636,7 +637,24 @@ HostIF_FastClockUnlock(int callerID) // IN
 static void *
 MapCrossPage(struct page *p)  // IN:
 {
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 8, 0)
    return vmap(&p, 1, VM_MAP, VM_PAGE_KERNEL_EXEC);
+#else
+   /* Starting with 5.8, vmap() always sets the NX bit, but the cross
+    * page needs to be executable. */
+   pte_t *ptes[1];
+   struct vm_struct *area = alloc_vm_area(1UL << PAGE_SHIFT, ptes);
+   if (area == NULL)
+      return NULL;
+
+   set_pte(ptes[0], mk_pte(p, VM_PAGE_KERNEL_EXEC));
+
+   preempt_disable();
+   __flush_tlb_all();
+   preempt_enable();
+
+   return area->addr;
+#endif
 }
 
 

--- a/vmmon-only/linux/hostif.c
+++ b/vmmon-only/linux/hostif.c
@@ -2614,7 +2614,11 @@ HostIF_SemaphoreWait(VMDriver *vm,   // IN:
     * reading no bytes (EAGAIN - non blocking fd) or sizeof(uint64).
     */
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 8, 0)
+   res = kernel_read(file, (char *) &value, sizeof value, &file->f_pos);
+#else
    res = file->f_op->read(file, (char *) &value, sizeof value, &file->f_pos);
+#endif
 
    if (res == sizeof value) {
       res = MX_WAITNORMAL;
@@ -2731,7 +2735,11 @@ HostIF_SemaphoreSignal(uint64 *args)  // IN:
     * it be present.
     */
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 8, 0)
+   res = kernel_write(file, (char *) &value, sizeof value, &file->f_pos);
+#else
    res = file->f_op->write(file, (char *) &value, sizeof value, &file->f_pos);
+#endif
 
    if (res == sizeof value) {
       res = MX_WAITNORMAL;


### PR DESCRIPTION
This fixes the freeze or reboot that occurs when starting a VM on 5.8+ with NX bit enabled. The change is somewhat inspired by the changes done in VirtualBox to address a similar issue.

The other commit addresses a NULL pointer issue that first arises with 5.8 kernels.

I'm not really a kernel hacker and cannot guarantee these changes are 100% correct, but I did successfully test them on two systems running two different kernels. One is running Fedora's 5.8.4-200.fc32.x86_64, the other a custom 5.8.6 built with clang. I didn't see any issues on these systems.

Update: I also did some testing on 5.9-rc3, along with the two 5.9-specific fixes already in the source branch, also with good results.