### PR TITLE
GCC 11.1.0 task_struct member fix

### DIFF
--- a/vmmon-only/linux/hostif.c
+++ b/vmmon-only/linux/hostif.c
@@ -475,7 +475,7 @@ HostIF_WakeUpYielders(VMDriver *vm,     // IN:
       ASSERT(vcpuid < vm->numVCPUs);
       t = vm->vmhost->vcpuSemaTask[vcpuid];
       VCPUSet_Remove(&req, vcpuid);
-      if (t && (t->state & TASK_INTERRUPTIBLE)) {
+      if (t && (t->__state & TASK_INTERRUPTIBLE)) {
          wake_up_process(t);
       }
    }
@@ -2580,14 +2580,14 @@ HostIF_SemaphoreWait(VMDriver *vm,   // IN:
    }
 
    poll_initwait(&table);
-   current->state = TASK_INTERRUPTIBLE;
+   current->__state = TASK_INTERRUPTIBLE;
    mask = file->f_op->poll(file, &table.pt);
    if (!(mask & (POLLIN | POLLERR | POLLHUP))) {
       vm->vmhost->vcpuSemaTask[vcpuid] = current;
       schedule_timeout(timeoutms * HZ / 1000);  // convert to Hz
       vm->vmhost->vcpuSemaTask[vcpuid] = NULL;
    }
-   current->state = TASK_RUNNING;
+   current->__state = TASK_RUNNING;
    poll_freewait(&table);
 
    /*
@@ -2669,7 +2669,7 @@ HostIF_SemaphoreForceWakeup(VMDriver *vm,       // IN:
        */
       struct task_struct *t =
          (struct task_struct *)xchg(&vm->vmhost->vcpuSemaTask[vcpuid], NULL);
-      if (t && (t->state & TASK_INTERRUPTIBLE)) {
+      if (t && (t->__state & TASK_INTERRUPTIBLE)) {
          wake_up_process(t);
       }
    } ROF_EACH_VCPU_IN_SET_WITH_MAX();


### PR DESCRIPTION
With GCC 11.1.0 an error occurs when making the vmmon module on Linux 5.14.0. This is due to a member reference on line 478, 2583, 2590, and 2672. This prevents the building of the module. The minor line changes fixes the member reference and allows this module to complies properly on stable Linux 5.14.0 with GCC 11.1.0.

The error I got before this patch is below:
make[1]: Entering directory '/usr/lib/modules/5.14.0-0/build'
  CC [M]  /usr/lib/vmware/modules/source/vmmon-only/linux/hostif.o
/usr/lib/vmware/modules/source/vmmon-only/linux/hostif.c: In function ‘HostIF_WakeUpYielders’:
/usr/lib/vmware/modules/source/vmmon-only/linux/hostif.c:478:20: error: ‘struct task_struct’ has no member named ‘state’; did you mean ‘__state’?
  478 |       if (t && (t->state & TASK_INTERRUPTIBLE)) {
      |                    ^~~~~
      |                    __state
/usr/lib/vmware/modules/source/vmmon-only/linux/hostif.c: In function ‘HostIF_SemaphoreWait’:
/usr/lib/vmware/modules/source/vmmon-only/linux/hostif.c:2583:13: error: ‘struct task_struct’ has no member named ‘state’; did you mean ‘__state’?
 2583 |    current->state = TASK_INTERRUPTIBLE;
      |             ^~~~~
      |             __state
/usr/lib/vmware/modules/source/vmmon-only/linux/hostif.c:2590:13: error: ‘struct task_struct’ has no member named ‘state’; did you mean ‘__state’?
 2590 |    current->state = TASK_RUNNING;
      |             ^~~~~
      |             __state
/usr/lib/vmware/modules/source/vmmon-only/linux/hostif.c: In function ‘HostIF_SemaphoreForceWakeup’:
/usr/lib/vmware/modules/source/vmmon-only/linux/hostif.c:2672:20: error: ‘struct task_struct’ has no member named ‘state’; did you mean ‘__state’?
 2672 |       if (t && (t->state & TASK_INTERRUPTIBLE)) {
      |                    ^~~~~
      |                    __state
make[2]: *** [scripts/Makefile.build:271: /usr/lib/vmware/modules/source/vmmon-only/linux/hostif.o] Error 1
make[1]: *** [Makefile:1851: /usr/lib/vmware/modules/source/vmmon-only] Error 2
make[1]: Leaving directory '/usr/lib/modules/5.14.0-0/build'
make: *** [Makefile:117: vmmon.ko] Error 2