### PR TITLE
Allow kernel version to be overridden

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ MODULES = vmmon vmnet
 SUBDIRS = $(MODULES:%=%-only)
 TARBALLS = $(MODULES:%=%.tar)
 MODFILES = $(foreach mod,$(MODULES),$(mod)-only/$(mod).ko)
-VM_UNAME = $(shell uname -r)
+VM_UNAME ?= $(shell uname -r)
 MODDIR = /lib/modules/$(VM_UNAME)/misc
 
 MODINFO = /sbin/modinfo

--- a/vmmon-only/Makefile
+++ b/vmmon-only/Makefile
@@ -43,7 +43,7 @@ INCLUDE      += -I$(SRCROOT)/shared
 endif
 
 
-VM_UNAME = $(shell uname -r)
+VM_UNAME ?= $(shell uname -r)
 
 # Header directory for the running kernel
 ifdef LINUXINCLUDE

--- a/vmnet-only/Makefile
+++ b/vmnet-only/Makefile
@@ -43,7 +43,7 @@ INCLUDE      += -I$(SRCROOT)/shared
 endif
 
 
-VM_UNAME = $(shell uname -r)
+VM_UNAME ?= $(shell uname -r)
 
 # Header directory for the running kernel
 ifdef LINUXINCLUDE


### PR DESCRIPTION
Currently the kernel version is determined from the running version. When updating the system, it is preferable to compile the modules for the new version before rebooting. This patch allows the kernel version to be overridden via by the environment variable VM_UNAME.