### PR TITLE
vmmon: work around build failure with -fsanitize=shift

### DIFF
--- a/vmmon-only/include/vm_asm_x86.h
+++ b/vmmon-only/include/vm_asm_x86.h
@@ -65,8 +65,9 @@
 #ifndef USE_UBSAN
 #define ASSERT_ON_COMPILE_SELECTOR_SIZE(expr)                                \
    ASSERT_ON_COMPILE(sizeof(Selector) == 2 &&                                \
-                     ((__builtin_constant_p(expr) && ((expr) >> 16) == 0) || \
-                      sizeof(expr) <= 2))
+		     __builtin_choose_expr(__builtin_constant_p(expr),       \
+					   ((expr) >> 16) == 0,              \
+					   sizeof(expr) <= 2))
 #else
 #define ASSERT_ON_COMPILE_SELECTOR_SIZE(expr)
 #endif


### PR DESCRIPTION
An old hack in ASSERT_ON_COMPILE_SELECTOR_SIZE() macro fails to compile
with -fsanitize=shift compiler option which Pop!_OS 21.10 distribution
started using recently. This is a known problem with __builtin_constant_p()
result not being considered constant in general. It is tracked as
https://gcc.gnu.org/bugzilla/show_bug.cgi?id=79482 but it is unclear when
it is going to be addressed.

Work around the issue by replacing the hack with __builtin_choose_expr()
which should work correctly with gcc >= 4.9, i.e. also any gcc version
supported by kernel upstream.

Fixes #136