### PR TITLE
Fix whitespace in vm_basic_defs.h from renaming of DO_ONCE macro

### DIFF
--- a/vmmon-only/include/vm_basic_defs.h
+++ b/vmmon-only/include/vm_basic_defs.h
@@ -750,7 +750,7 @@ typedef int pid_t;
                                                      lfMessageFont)
 
 /* This is not intended to be thread-safe. */
-#define VMWARE_DO_ONCE(code)                                                   \
+#define VMWARE_DO_ONCE(code)                                            \
    do {                                                                 \
       static MONITOR_ONLY(PERVCPU) Bool _doOnceDone = FALSE;            \
       if (UNLIKELY(!_doOnceDone)) {                                     \

--- a/vmnet-only/vm_basic_defs.h
+++ b/vmnet-only/vm_basic_defs.h
@@ -750,7 +750,7 @@ typedef int pid_t;
                                                      lfMessageFont)
 
 /* This is not intended to be thread-safe. */
-#define VMWARE_DO_ONCE(code)                                                   \
+#define VMWARE_DO_ONCE(code)                                            \
    do {                                                                 \
       static MONITOR_ONLY(PERVCPU) Bool _doOnceDone = FALSE;            \
       if (UNLIKELY(!_doOnceDone)) {                                     \


### PR DESCRIPTION
Remove some unnecessary whitespace from the renaming of the `DO_ONCE` macro to `VMWARE_DO_ONCE`.