### PR TITLE
vmnet: support stable kernels with netdevice::dev_addr changes

### DIFF
--- a/vmnet-only/netif.c
+++ b/vmnet-only/netif.c
@@ -68,6 +68,9 @@ static int  VNetNetIfProcRead(char *page, char **start, off_t off,
                               int count, int *eof, void *data);
 
 #if LINUX_VERSION_CODE < KERNEL_VERSION(5, 15, 0) && \
+    (LINUX_VERSION_CODE > KERNEL_VERSION(4, 19, 0) && LINUX_VERSION_CODE < KERNEL_VERSION(4, 19, 291)) && \
+    (LINUX_VERSION_CODE > KERNEL_VERSION(5, 4, 0) && LINUX_VERSION_CODE < KERNEL_VERSION(5, 4, 251)) && \
+    (LINUX_VERSION_CODE > KERNEL_VERSION(5, 10, 0) && LINUX_VERSION_CODE < KERNEL_VERSION(5, 10, 188)) && \
     !defined(RHEL86_BACKPORTS) && !defined(SLE15_SP3_BACKPORTS)
 static void
 __dev_addr_set(struct net_device *dev, const void *addr, size_t len)


### PR DESCRIPTION
Stable backported 48eab831ae8b ("net: create netdev->dev_addr assignment helpers") to the 4.19, 5.4 and 5.10 series, so we need to skip our compat helpers for high enough patch levels.

(Also, sorry for all the PR spam, but there seems to be no better way to get that included. I wish there were a way to create one PR for multiple branches...)