### PR TITLE
Workstation 17.5.1 k5.14

### DIFF
--- a/vmmon-only/include/pgtbl.h
+++ b/vmmon-only/include/pgtbl.h
@@ -88,7 +88,7 @@ PgtblVa2MPNLocked(struct mm_struct *mm, // IN: Mm structure of a process
          if (pmd_large(*pmd)) {
             mpn = pmd_pfn(*pmd) + ((addr & ~PMD_MASK) >> PAGE_SHIFT);
          } else {
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,5,0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,5,0) || RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(9, 4)
             pte_t *pte = pte_offset_kernel(pmd, addr);
 #else
             pte_t *pte = pte_offset_map(pmd, addr);

--- a/vmnet-only/bridge.c
+++ b/vmnet-only/bridge.c
@@ -26,7 +26,7 @@
 #include <linux/slab.h>
 #include <linux/poll.h>
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 4, 10)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 4, 10) || RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(9, 4)
 #include <net/gso.h>
 #endif
 #include <linux/netdevice.h>

--- a/vmnet-only/userif.c
+++ b/vmnet-only/userif.c
@@ -546,7 +546,7 @@ VNetCsumAndCopyToUser(const void *src,   // IN: Source
 
 #if COMPAT_LINUX_VERSION_CHECK_LT(5, 10, 0)
    csum = csum_and_copy_to_user(src, dst, len, 0, err);
-#elif LINUX_VERSION_CODE < KERNEL_VERSION(5, 19, 0)
+#elif LINUX_VERSION_CODE < KERNEL_VERSION(5, 14, 0)
    csum = csum_and_copy_to_user(src, dst, len);
    *err = (csum == 0) ? -EFAULT : 0;
 #else


### PR DESCRIPTION
Fixes the build for the current Rocky Linux 9.5 Kernel 5.14.x

This may require to copy over `vmlinux` to build, for BTF generation:

    sudo dnf install dwarves
    sudo cp /sys/kernel/btf/vmlinux /usr/lib/modules/`uname -r`/build/

Manually inserting the modules is required, but both are working:

    sudo insmod vmnet-only/vmnet.ko
    sudo insmod vmmon-only/vmmon.ko

closes #241, closes #289.