### PR TITLE
modules: fix build with kernel >= 6.16.0 + Workstation 17.6.4

### DIFF
--- a/vmmon-only/Makefile.kernel
+++ b/vmmon-only/Makefile.kernel
@@ -21,6 +21,7 @@ CC_OPTS += -DVMMON -DVMCORE
 
 INCLUDE := -I$(SRCROOT)/include -I$(SRCROOT)/include/x86 -I$(SRCROOT)/common -I$(SRCROOT)/linux
 EXTRA_CFLAGS := $(CC_OPTS) $(INCLUDE)
+ccflags-y := $(CC_OPTS) $(INCLUDE)
 
 obj-m += $(DRIVER).o
 

--- a/vmmon-only/common/crosspage.c
+++ b/vmmon-only/common/crosspage.c
@@ -671,7 +671,16 @@ CrossPage_CodePage(void)
      [crossGDTHKLADesc]   "i" (offsetof(VMCrossPageData, crossGDTHKLADesc)),
      [switchHostIDTR]     "i" (offsetof(VMCrossPageData, switchHostIDTR))
    );
+#ifdef CONFIG_RETHUNK
+   /*
+    * With CONFIG_RETHUNK, objtool requires an explicit return instruction
+    * instead of relying on __builtin_unreachable(). Otherwise we get
+    * "'naked' return found in MITIGATION_RETHUNK build".
+    */
+   __asm__ __volatile__("ret\n");
+#else
    NOT_REACHED_MINIMAL();
+#endif
 }
 
 #ifdef STACK_FRAME_NON_STANDARD

--- a/vmmon-only/common/vmx86.c
+++ b/vmmon-only/common/vmx86.c
@@ -1,3 +1,4 @@
+#include "../include/compat_entropy.h"
 /*********************************************************
  * Copyright (C) 1998-2022 VMware, Inc. All rights reserved.
  *

--- a/vmmon-only/include/compat_entropy.h
+++ b/vmmon-only/include/compat_entropy.h
@@ -1,0 +1,11 @@
+#ifndef _VMW_COMPAT_ENTROPY_H_
+#define _VMW_COMPAT_ENTROPY_H_
+
+/* Prototype only: timex.h (and other kernel headers) may call
+ * random_get_entropy_fallback() — ensure a prototype is visible.
+ */
+#ifndef HAVE_RANDOM_GET_ENTROPY_FALLBACK
+unsigned long random_get_entropy_fallback(void);
+#endif
+
+#endif /* _VMW_COMPAT_ENTROPY_H_ */

--- a/vmmon-only/include/compat_pgtable.h
+++ b/vmmon-only/include/compat_pgtable.h
@@ -78,5 +78,17 @@ typedef pgd_t compat_p4d_t;
 #define VM_PAGE_KERNEL_EXEC PAGE_KERNEL_EXEC
 #endif
 
+#ifndef pgd_large
+#define pgd_large(x) (0)
+#endif
+#ifndef p4d_large
+#define p4d_large(x) (0)
+#endif
+#ifndef pud_large
+#define pud_large(x) (0)
+#endif
+#ifndef pmd_large
+#define pmd_large(x) (0)
+#endif
 
 #endif /* __COMPAT_PGTABLE_H__ */

--- a/vmmon-only/include/iocontrols.h
+++ b/vmmon-only/include/iocontrols.h
@@ -146,7 +146,7 @@ PtrToVA64(void const *ptr) // IN
  * the NT specific VMX86_DRIVER_VERSION.
  */
 
-#define VMMON_VERSION           (416 << 16 | 0)
+#define VMMON_VERSION           (417 << 16 | 0)
 #define VMMON_VERSION_MAJOR(v)  ((uint32) (v) >> 16)
 #define VMMON_VERSION_MINOR(v)  ((uint16) (v))
 
@@ -552,7 +552,7 @@ typedef struct VMProcessBootstrapBlock {
    uint32         headerOffset;  // IN: Offset of header in blob.
    uint16         numVCPUs;      // IN: Number of VCPUs.
    VMSharedRegion shRegions[ML_SHARED_REGIONS_MAX]; // IN: Shared regions.
-   PerVcpuPages   perVcpuPages[0];
+   PerVcpuPages   perVcpuPages[];
 } VMProcessBootstrapBlock;
 
 /*

--- a/vmmon-only/linux/driver.c
+++ b/vmmon-only/linux/driver.c
@@ -34,6 +34,7 @@
 
 #include "compat_version.h"
 #include "compat_module.h"
+#include "compat_entropy.h"
 
 #include "usercalldefs.h"
 
@@ -345,7 +346,11 @@ LinuxDriverExit(void)
 
    Log("Module %s: unloaded\n", vmmon_miscdev.name);
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 15, 4)
+   timer_delete_sync(&tscTimer);
+#else
    del_timer_sync(&tscTimer);
+#endif
 
    Vmx86_CleanupHVIOBitmap();
    Task_Terminate();
@@ -1431,3 +1436,18 @@ MODULE_LICENSE("GPL v2");
 MODULE_INFO(supported, "external");
 module_init(LinuxDriverInit);
 module_exit(LinuxDriverExit);
+
+/* Compatibility: provide a non-static implementation of
+ * random_get_entropy_fallback so every TU can link to it.
+ */
+#ifndef HAVE_RANDOM_GET_ENTROPY_FALLBACK
+#include <linux/random.h>
+unsigned long random_get_entropy_fallback(void)
+{
+#if defined(CONFIG_ARCH_RANDOM)
+    return random_get_entropy();
+#else
+    return 0;
+#endif
+}
+#endif

--- a/vmmon-only/linux/hostif.c
+++ b/vmmon-only/linux/hostif.c
@@ -1994,7 +1994,11 @@ HostIF_InitUptime(void)
 void
 HostIF_CleanupUptime(void)
 {
-   del_timer_sync(&uptimeState.timer);
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 15, 4)
+   timer_delete_sync(&uptimeState.timer);
+#else
+   del_timer_sync(&tscTimer);
+#endif
 }
 
 
@@ -3409,7 +3413,11 @@ HostIF_SafeRDMSR(unsigned int msr,   // IN
    int err;
    u64 v;
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 16, 0)
+   err = rdmsrq_safe(msr, &v);
+#else
    err = rdmsrl_safe(msr, &v);
+#endif
    *val = (err == 0) ? v : 0;  // Linux corrupts 'v' on error
 
    return err;

--- a/vmmon-only/linux/hostif.c
+++ b/vmmon-only/linux/hostif.c
@@ -1997,7 +1997,7 @@ HostIF_CleanupUptime(void)
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 15, 4)
    timer_delete_sync(&uptimeState.timer);
 #else
-   del_timer_sync(&tscTimer);
+   del_timer_sync(&uptimeState.timer);
 #endif
 }
 

--- a/vmnet-only/driver.c
+++ b/vmnet-only/driver.c
@@ -279,7 +279,7 @@ VNetRemovePortFromList(const VNetPort *port) // IN: port to remove from list
 /*
  *----------------------------------------------------------------------
  *
- * init_module --
+ * vmnet_module_init --
  *
  *      linux module entry point. Called by /sbin/insmod command.
  *      Initializes module and Registers this driver for a
@@ -295,8 +295,8 @@ VNetRemovePortFromList(const VNetPort *port) // IN: port to remove from list
  *----------------------------------------------------------------------
  */
 
-int
-init_module(void)
+static int
+vmnet_module_init(void)
 {
    int retval;
 
@@ -353,12 +353,13 @@ err_proto:
    VNetProc_Cleanup();
    return retval;
 }
+module_init(vmnet_module_init);
 
 
 /*
  *----------------------------------------------------------------------
  *
- * cleanup_module --
+ * vmnet_module_cleanup --
  *
  *      Called by /sbin/rmmod.  Unregisters this driver for a
  *      vnet major #, and deinitializes the modules.  The 64-bit
@@ -374,13 +375,14 @@ err_proto:
  *----------------------------------------------------------------------
  */
 
-void
-cleanup_module(void)
+static void
+vmnet_module_cleanup(void)
 {
    unregister_chrdev(VNET_MAJOR_NUMBER, "vmnet");
    VNetProtoUnregister();
    VNetProc_Cleanup();
 }
+module_exit(vmnet_module_cleanup);
 
 
 /*

--- a/vmnet-only/vmnetInt.h
+++ b/vmnet-only/vmnetInt.h
@@ -41,9 +41,18 @@
     compat_skb_set_network_header(skb, sizeof (struct ethhdr)),  \
     dev_queue_xmit(skb)                                   \
   )
+
+#if defined(CONFIG_NET) && defined(dev_base_lock)
+/* Older kernels: dev_base_lock present */
 #define dev_lock_list()    read_lock(&dev_base_lock)
 #define dev_unlock_list()  read_unlock(&dev_base_lock)
 
+#else
+/* Newer kernels removed dev_base_lock -> use rtnl locking as fallback */
+#include <linux/rtnetlink.h>
+#define dev_lock_list()    rtnl_lock()
+#define dev_unlock_list()  rtnl_unlock()
+#endif
 
 extern struct proto vmnet_proto;
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 2, 0) || defined(sk_net_refcnt)


### PR DESCRIPTION
This a branch which fix build with kernel >= 6.16.0 + Workstation 17.6.4
Tested with

```
$ uname -r
6.16.5-1-liquorix-amd64
$ vmware --version
VMware Workstation 17.6.4 build-24832109
```

To test :
```
make
sudo make install
sudo systemctl restart vmware
```

Thank you
---
Aurelien BOUIN